### PR TITLE
Handle tags in localized names

### DIFF
--- a/src/gui/search.lua
+++ b/src/gui/search.lua
@@ -105,7 +105,7 @@ handlers = {
       local player_table = global.players[e.player_index]
       local gui_data = player_table.gui.search
       if e.keyboard_confirm or gui_data.state ~= 'select_result' then
-        local _,_,object_name = e.element.get_item(e.element.selected_index):find('^.*/(.*)%].*$')
+        local _,_,object_name = e.element.get_item(e.element.selected_index):find('^[^/]*/([^%]]*)%].*$')
         event.raise(open_gui_event, {player_index=e.player_index, gui_type=gui_data.category, object_name=object_name, source_data={mod_name='RecipeBook',
           gui_name='search', category=gui_data.category, query=gui_data.search_textfield.text, selected_index=e.element.selected_index}})
         if e.keyboard_confirm then


### PR DESCRIPTION
Fixes crashes regarding items with colored text in Krastorio 2.

Localized names can contain '/' or ']', but the regex that handles extracting the item name from the list entry doesn't handle that. Only match the first '/' and ']'.