### PR TITLE
Technology Bonuses WIP

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -29,7 +29,6 @@ constants.disabled_recipe_categories = {
 }
 
 constants.class_to_font_glyph = {
-  bonus = "G",
   crafter = "D",
   fluid = "B",
   item = "C",
@@ -41,7 +40,6 @@ constants.class_to_font_glyph = {
 }
 
 constants.class_to_type = {
-  bonus = "utility",
   crafter = "entity",
   fluid = "fluid",
   item = "item",
@@ -80,8 +78,6 @@ constants.colors = {
 }
 
 constants.empty_translations_table = {
-  bonus = {},
-  bonus_description = {},
   gui = {},
   crafter = {},
   crafter_description = {},
@@ -103,7 +99,6 @@ constants.empty_translations_table = {
 
 constants.gui_strings = {
   -- internal classes
-  {dictionary = "gui", internal = "bonus", localised = {"rb-gui.bonus"}},
   {dictionary = "gui", internal = "crafter", localised = {"rb-gui.crafter"}},
   {dictionary = "gui", internal = "fluid", localised = {"rb-gui.fluid"}},
   {dictionary = "gui", internal = "item", localised = {"rb-gui.item"}},
@@ -144,9 +139,6 @@ constants.gui_strings = {
   {dictionary = "gui", internal = "required_fluid", localised = {"rb-gui.required-fluid"}},
   {dictionary = "gui", internal = "research_units_tooltip", localised = {"rb-gui.research-units-tooltip"}},
   {dictionary = "gui", internal = "research_ingredients_per_unit_tooltip", localised = {"rb-gui.research-ingredients-per-unit-tooltip"}},
-
-  
-  
   {dictionary = "gui", internal = "researching_speed", localised = {"rb-gui.researching-speed"}},
   {dictionary = "gui", internal = "rocket_parts_required", localised = {"rb-gui.rocket-parts-required"}},
   {dictionary = "gui", internal = "seconds_standalone", localised = {"rb-gui.seconds-standalone"}},

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -29,6 +29,7 @@ constants.disabled_recipe_categories = {
 }
 
 constants.class_to_font_glyph = {
+  bonus = "G",
   crafter = "D",
   fluid = "B",
   item = "C",
@@ -40,6 +41,7 @@ constants.class_to_font_glyph = {
 }
 
 constants.class_to_type = {
+  bonus = "utility",
   crafter = "entity",
   fluid = "fluid",
   item = "item",
@@ -78,6 +80,8 @@ constants.colors = {
 }
 
 constants.empty_translations_table = {
+  bonus = {},
+  bonus_description = {},
   gui = {},
   crafter = {},
   crafter_description = {},
@@ -99,6 +103,7 @@ constants.empty_translations_table = {
 
 constants.gui_strings = {
   -- internal classes
+  {dictionary = "gui", internal = "bonus", localised = {"rb-gui.bonus"}},
   {dictionary = "gui", internal = "crafter", localised = {"rb-gui.crafter"}},
   {dictionary = "gui", internal = "fluid", localised = {"rb-gui.fluid"}},
   {dictionary = "gui", internal = "item", localised = {"rb-gui.item"}},
@@ -137,6 +142,11 @@ constants.gui_strings = {
   {dictionary = "gui", internal = "products_tooltip", localised = {"rb-gui.products-tooltip"}},
   {dictionary = "gui", internal = "pumping_speed", localised = {"rb-gui.pumping-speed"}},
   {dictionary = "gui", internal = "required_fluid", localised = {"rb-gui.required-fluid"}},
+  {dictionary = "gui", internal = "research_units_tooltip", localised = {"rb-gui.research-units-tooltip"}},
+  {dictionary = "gui", internal = "research_ingredients_per_unit_tooltip", localised = {"rb-gui.research-ingredients-per-unit-tooltip"}},
+
+  
+  
   {dictionary = "gui", internal = "researching_speed", localised = {"rb-gui.researching-speed"}},
   {dictionary = "gui", internal = "rocket_parts_required", localised = {"rb-gui.rocket-parts-required"}},
   {dictionary = "gui", internal = "seconds_standalone", localised = {"rb-gui.seconds-standalone"}},

--- a/src/locale/en/RecipeBook.cfg
+++ b/src/locale/en/RecipeBook.cfg
@@ -23,6 +23,7 @@ rb-crafter-blueprint=A temporary blueprint provided by the Recipe Book to quickl
 [rb-gui]
 add-to-favorites=Add to favorites
 blueprint-not-available=A blueprint is not available for this crafter.
+bonus=Bonus
 category=Category:
 click-to-view-required-fluid=[font=default-semibold][color=128, 206, 240]Click:[/color][/font] View required fluid.
 click-to-view=[font=default-semibold][color=128, 206, 240]Click:[/color][/font] View details.
@@ -76,7 +77,9 @@ recipe=Recipe
 remove-from-favorites=Remove from favorites
 required-fluid=Required fluid:
 research-ingredients-per-unit=Research ingredients per unit (__1__)
+research-ingredients-per-unit-tooltip=Research ingredients per unit:
 research-units=Units required to research
+research-units-tooltip=Units required to research:
 researching-speed=Researching speed:
 resource=Resource
 results-limited=Results limited to __1__ items
@@ -130,11 +133,14 @@ technology=Technology
 temperature-variants=Temperature variants (__1__)
 units-research-tooltip=The amount of units to research in the lab to complete technology .\nFor infinite technologies, displayed value is for lowest level of technology.
 unlocked-by=Unlocked by (__1__)
+unlocks-bonuses=Unlocks bonuses (__1__)
+unlocks-fluids=Unlocks fluids (__1__)
+unlocks-items=Unlocks items (__1__)
 unlocks-recipes=Unlocks recipes (__1__)
 unresearched=Unresearched
 usable-in=Usable in (__1__)
 view-base-fluid=View base fluid
-view-details=View details
+view-details=View details   
 view-in-technology-gui=View in technology GUI.
 
 [rb-message]

--- a/src/locale/en/RecipeBook.cfg
+++ b/src/locale/en/RecipeBook.cfg
@@ -23,7 +23,6 @@ rb-crafter-blueprint=A temporary blueprint provided by the Recipe Book to quickl
 [rb-gui]
 add-to-favorites=Add to favorites
 blueprint-not-available=A blueprint is not available for this crafter.
-bonus=Bonus
 category=Category:
 click-to-view-required-fluid=[font=default-semibold][color=128, 206, 240]Click:[/color][/font] View required fluid.
 click-to-view=[font=default-semibold][color=128, 206, 240]Click:[/color][/font] View details.
@@ -133,14 +132,13 @@ technology=Technology
 temperature-variants=Temperature variants (__1__)
 units-research-tooltip=The amount of units to research in the lab to complete technology .\nFor infinite technologies, displayed value is for lowest level of technology.
 unlocked-by=Unlocked by (__1__)
-unlocks-bonuses=Unlocks bonuses (__1__)
 unlocks-fluids=Unlocks fluids (__1__)
 unlocks-items=Unlocks items (__1__)
 unlocks-recipes=Unlocks recipes (__1__)
 unresearched=Unresearched
 usable-in=Usable in (__1__)
 view-base-fluid=View base fluid
-view-details=View details   
+view-details=View details
 view-in-technology-gui=View in technology GUI.
 
 [rb-message]

--- a/src/scripts/formatter.lua
+++ b/src/scripts/formatter.lua
@@ -166,6 +166,14 @@ end
 local ingredients_products_keys = {ingredients = true, products = true}
 
 local formatters = {
+  bonus = {
+    tooltip = function(obj_data, player_data, is_hidden, is_researched, _)
+      local base_str = get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+
+      return base_str
+    end,
+    enabled = function() return false end
+  },
   crafter = {
     tooltip = function(obj_data, player_data, is_hidden, is_researched, is_label, blueprint_recipe)
       -- locals
@@ -484,6 +492,57 @@ local formatters = {
     tooltip = function(obj_data, player_data, is_hidden, is_researched, is_label)
       local base_str = get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
       local gui_translations = player_data.translations.gui
+      local player_settings = player_data.settings
+      local recipe_book = global.recipe_book
+
+      -- units count, ingredients
+      local tech_str_arr = {}
+      if player_settings.show_detailed_recipe_tooltips and not is_label then
+        -- units count
+        local unit_count = obj_data.research_unit_count or game.evaluate_expression(
+          obj_data.research_unit_count_formula,
+          {L = obj_data.min_level, l = obj_data.min_level}
+        )
+
+        tech_str_arr[1] = (
+          "\n"
+          ..build_rich_text("font", "default-semibold", gui_translations.research_units_tooltip)
+          .." "..unit_count
+        )
+        tech_str_arr[#tech_str_arr+1] = (
+          "\n"
+          ..build_rich_text("font", "default-semibold", gui_translations.research_ingredients_per_unit_tooltip)
+        )
+
+        -- time ingredient
+        if obj_data.research_unit_energy then
+          local time_item_prefix = player_data.settings.show_glyphs and "[font=RecipeBook]Z[/font]   " or ""
+          tech_str_arr[#tech_str_arr+1] = "\n  ".. time_item_prefix.."[img=quantity-time]   "
+          ..obj_data.research_unit_energy.." "..gui_translations.seconds_standalone
+                    
+        end
+        -- ingredients
+        local ingredients = obj_data.research_ingredients_per_unit
+        for i = 1, #ingredients do
+          local ingredient = ingredients[i]
+          local ingredient_data = recipe_book[ingredient.class][ingredient.name]
+          if ingredient_data then
+            local data = formatter(
+              ingredient_data,
+              player_data,
+              {amount_string = ingredient.amount_string, always_show = true}
+            )
+            local label = data.caption
+            if data.is_researched then
+              tech_str_arr[#tech_str_arr+1] = "\n  "..label
+            else
+              tech_str_arr[#tech_str_arr+1] = "\n  "..build_rich_text("color", "unresearched", label)
+            end
+          end
+        end
+      end
+
+      local tech_str = concat(tech_str_arr)
       -- interaction help
       local interaction_help_str = ""
       if not is_label then
@@ -491,7 +550,7 @@ local formatters = {
         interaction_help_str = interaction_help_str.."\n"..player_data.translations.gui.shift_click_to_view_technology
       end
 
-      return base_str..interaction_help_str
+      return base_str..tech_str..interaction_help_str
     end,
     enabled = function() return true end
   }

--- a/src/scripts/global-data.lua
+++ b/src/scripts/global-data.lua
@@ -19,7 +19,6 @@ end
 function global_data.build_recipe_book()
   -- the data that will actually be saved and used
   local recipe_book = {
-    bonus = {},
     crafter = {},
     fluid = {},
     item = {},

--- a/src/scripts/global-data.lua
+++ b/src/scripts/global-data.lua
@@ -19,6 +19,7 @@ end
 function global_data.build_recipe_book()
   -- the data that will actually be saved and used
   local recipe_book = {
+    bonus = {},
     crafter = {},
     fluid = {},
     item = {},

--- a/src/scripts/gui/main/pages/technology.lua
+++ b/src/scripts/gui/main/pages/technology.lua
@@ -33,8 +33,11 @@ function technology_page.build()
       }
     ),
     info_list_box.build({"rb-gui.unlocks-recipes"}, 1, {"technology", "associated_recipes"}),
+    info_list_box.build({"rb-gui.unlocks-bonuses"}, 1, {"technology", "associated_bonuses"}),
     info_list_box.build({"rb-gui.prerequisites"}, 1, {"technology", "prerequisites"}),
     info_list_box.build({"rb-gui.prerequisite-of"}, 1, {"technology", "prerequisite_of"}),
+    info_list_box.build({"rb-gui.unlocks-items"}, 1, {"technology", "associated_items"}),
+    info_list_box.build({"rb-gui.unlocks-fluids"}, 1, {"technology", "associated_fluids"}),
   }
 
   return elems
@@ -78,8 +81,11 @@ function technology_page.update(int_name, gui_data, player_data)
       {always_show = true, starting_index = 1}
     )
     + info_list_box.update(obj_data.associated_recipes, refs.technology.associated_recipes, player_data)
+    + info_list_box.update(obj_data.associated_bonuses, refs.technology.associated_bonuses, player_data)
     + info_list_box.update(obj_data.prerequisites, refs.technology.prerequisites, player_data)
     + info_list_box.update(obj_data.prerequisite_of, refs.technology.prerequisite_of, player_data)
+    + info_list_box.update(obj_data.associated_items, refs.technology.associated_items, player_data)
+    + info_list_box.update(obj_data.associated_fluids, refs.technology.associated_fluids, player_data)
 end
 
 function technology_page.update_unit_count(obj_data, refs, state, settings)

--- a/src/scripts/gui/main/pages/technology.lua
+++ b/src/scripts/gui/main/pages/technology.lua
@@ -32,12 +32,11 @@ function technology_page.build()
         }
       }
     ),
+    info_list_box.build({"rb-gui.unlocks-fluids"}, 1, {"technology", "associated_fluids"}),
+    info_list_box.build({"rb-gui.unlocks-items"}, 1, {"technology", "associated_items"}),
     info_list_box.build({"rb-gui.unlocks-recipes"}, 1, {"technology", "associated_recipes"}),
-    info_list_box.build({"rb-gui.unlocks-bonuses"}, 1, {"technology", "associated_bonuses"}),
     info_list_box.build({"rb-gui.prerequisites"}, 1, {"technology", "prerequisites"}),
     info_list_box.build({"rb-gui.prerequisite-of"}, 1, {"technology", "prerequisite_of"}),
-    info_list_box.build({"rb-gui.unlocks-items"}, 1, {"technology", "associated_items"}),
-    info_list_box.build({"rb-gui.unlocks-fluids"}, 1, {"technology", "associated_fluids"}),
   }
 
   return elems
@@ -80,13 +79,12 @@ function technology_page.update(int_name, gui_data, player_data)
       player_data,
       {always_show = true, starting_index = 1}
     )
+    + info_list_box.update(obj_data.associated_fluids, refs.technology.associated_fluids, player_data)
+    + info_list_box.update(obj_data.associated_items, refs.technology.associated_items, player_data)
     + info_list_box.update(obj_data.associated_recipes, refs.technology.associated_recipes, player_data)
-    + info_list_box.update(obj_data.associated_bonuses, refs.technology.associated_bonuses, player_data)
     + info_list_box.update(obj_data.prerequisites, refs.technology.prerequisites, player_data)
     + info_list_box.update(obj_data.prerequisite_of, refs.technology.prerequisite_of, player_data)
-    + info_list_box.update(obj_data.associated_items, refs.technology.associated_items, player_data)
-    + info_list_box.update(obj_data.associated_fluids, refs.technology.associated_fluids, player_data)
-end
+ end
 
 function technology_page.update_unit_count(obj_data, refs, state, settings)
   -- set units item

--- a/src/scripts/processors/technology.lua
+++ b/src/scripts/processors/technology.lua
@@ -7,7 +7,6 @@ local fluid_proc = require("scripts.processors.fluid")
 return function(recipe_book, strings, metadata)
   for name, prototype in pairs(game.technology_prototypes) do
     if prototype.enabled then
-      local associated_bonuses = {}
       local associated_fluids = {}
       local associated_items = {}
       local associated_recipes = {}
@@ -85,36 +84,6 @@ return function(recipe_book, strings, metadata)
               end
             end
           end
-        else
-          if not recipe_book.bonus[modifier.type] then
-              recipe_book.bonus[modifier.type] = { class = "bonus", name = modifier.type, prototype_name = modifier.type:gsub( "-", "_").."_modifier_icon" }
-            
-            local bonus_amount_string = ""
-
-            if modifier.modifier ~= true then
-              if modifier.modifier > 1 then
-                bonus_amount_string = modifier.modifier
-              else
-                bonus_amount_string = (modifier.modifier * 100) .."%"
-              end
-            end
-
-            util.add_string(strings, {
-              dictionary = "bonus",
-              internal = modifier.type,
-              localised = { "modifier-description."..modifier.type, bonus_amount_string }
-            })            
-            util.add_string(strings, {
-              dictionary = "bonus_description",
-              internal = modifier.type,
-              localised =  { "modifier-description."..modifier.type, bonus_amount_string }
-            })
-
-          end
-          associated_bonuses[#associated_bonuses+1] = {
-            class = "bonus",
-            name = modifier.type      
-            }
         end
       end
 
@@ -122,7 +91,6 @@ return function(recipe_book, strings, metadata)
       local max_level = prototype.max_level
 
       recipe_book.technology[name] = {
-        associated_bonuses = associated_bonuses,
         associated_fluids = associated_fluids,
         associated_items = associated_items,
         associated_recipes = associated_recipes,

--- a/src/scripts/processors/technology.lua
+++ b/src/scripts/processors/technology.lua
@@ -55,7 +55,7 @@ return function(recipe_book, strings, metadata)
                 product_data.temperature_data,
                 {unlocked_by = {class = "technology", name = name}}
               )
-              associated_product.name = associated_product.name..product_data.temperature_string
+              associated_product.name = product_data.name
             else
               product_data.unlocked_by[#product_data.unlocked_by + 1] = {class = "technology", name = name}
             end
@@ -65,7 +65,6 @@ return function(recipe_book, strings, metadata)
                 associated_items[#associated_items+1] = associated_product
                 associated_items[associated_product.name] = true
               end
-              
             elseif product_data.class == "fluid" then
               if not associated_fluids[associated_product.name] then
                 associated_fluids[#associated_fluids+1] = associated_product
@@ -88,7 +87,7 @@ return function(recipe_book, strings, metadata)
           end
         else
           if not recipe_book.bonus[modifier.type] then
-            recipe_book.bonus[modifier.type] = { class = "bonus", name = modifier.type, prototype_name = modifier.type:gsub( "-", "_").."_modifier_icon" }
+              recipe_book.bonus[modifier.type] = { class = "bonus", name = modifier.type, prototype_name = modifier.type:gsub( "-", "_").."_modifier_icon" }
             
             local bonus_amount_string = ""
 

--- a/src/scripts/tooltip-formatters/crafter.lua
+++ b/src/scripts/tooltip-formatters/crafter.lua
@@ -1,0 +1,113 @@
+local crafter = {}
+
+local math = require("__flib__.math")
+
+local base_functions
+
+crafter.init = function(functions)
+    base_functions = functions
+end
+
+crafter.tooltip_formatter =function(obj_data, player_data, is_hidden, is_researched, is_label, blueprint_recipe)
+    -- locals
+    local translations = player_data.translations
+    local gui_translations = translations.gui
+
+    -- object properties
+    local categories = obj_data.categories
+    local rocket_parts_required = obj_data.rocket_parts_required
+    local fixed_recipe = obj_data.fixed_recipe
+
+    -- build string
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- rocket parts
+    local rocket_parts_str = ""
+    if rocket_parts_required then
+      rocket_parts_str = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.rocket_parts_required)
+        .." "
+        ..rocket_parts_required
+      )
+    end
+    -- fixed recipe
+    local fixed_recipe_str = ""
+    local fixed_recipe_help_str = ""
+    if fixed_recipe then
+      -- get fixed recipe data
+      local fixed_recipe_data = global.recipe_book.recipe[obj_data.fixed_recipe]
+      if fixed_recipe_data then
+        local title_str = ("\n"..base_functions.build_rich_text("font", "default-semibold", gui_translations.fixed_recipe).."  ")
+        -- fixed recipe
+        local data = base_functions.formatter(fixed_recipe_data, player_data, {always_show = true})
+        local label = data.caption
+        -- remove glyph from caption, since it's implied
+        if player_data.settings.show_glyphs then
+          label = string.gsub(label, "^.-nt%]  ", "")
+        end
+        if data.is_researched then
+          fixed_recipe_str = title_str..label
+        else
+          fixed_recipe_str = title_str..base_functions.build_rich_text("color", "unresearched", label)
+        end
+        -- help text
+        if not is_label then
+          fixed_recipe_help_str = "\n"..gui_translations.control_click_to_view_fixed_recipe
+        end
+      end
+    end
+    -- crafting speed
+    local crafting_speed_str = (
+      "\n"
+      ..base_functions.build_rich_text("font", "default-semibold", gui_translations.crafting_speed)
+      .." "
+      ..math.round_to(obj_data.crafting_speed, 2)
+    )
+    -- crafting categories
+    local crafting_categories_str_arr = {
+      "\n"
+      ..base_functions.build_rich_text("font", "default-semibold", gui_translations.crafting_categories)
+    }
+    for i = 1, #categories do
+      crafting_categories_str_arr[#crafting_categories_str_arr+1] = "\n  "..categories[i]
+    end
+    local crafting_categories_str = base_functions.concat(crafting_categories_str_arr)
+    -- fuel categories
+    local fuel_categories_str_arr = {}
+    local fuel_categories = obj_data.fuel_categories
+    if fuel_categories then
+      fuel_categories_str_arr[1] = "\n"..base_functions.build_rich_text("font", "default-semibold", gui_translations.fuel_categories)
+      for i = 1, #fuel_categories do
+        fuel_categories_str_arr[#fuel_categories_str_arr+1] = "\n  "..fuel_categories[i]
+      end
+    end
+    local fuel_categories_str = base_functions.concat(fuel_categories_str_arr)
+    local open_page_help_str = ""
+    local blueprintable_str = ""
+    if not is_label then
+      -- open page help
+      open_page_help_str = "\n"..gui_translations.click_to_view
+      -- blueprintable
+      if blueprint_recipe then
+        if obj_data.blueprintable then
+          blueprintable_str = "\n"..gui_translations.shift_click_to_get_blueprint
+        else
+          blueprintable_str = "\n"..base_functions.build_rich_text("color", "error", gui_translations.blueprint_not_available)
+        end
+      end
+    end
+
+    return (
+      base_str
+      ..rocket_parts_str
+      ..fixed_recipe_str
+      ..crafting_speed_str
+      ..crafting_categories_str
+      ..fuel_categories_str
+      ..open_page_help_str
+      ..blueprintable_str
+      ..fixed_recipe_help_str
+    )
+end
+
+return crafter

--- a/src/scripts/tooltip-formatters/fluid.lua
+++ b/src/scripts/tooltip-formatters/fluid.lua
@@ -1,0 +1,38 @@
+local fluid = {}
+
+local base_functions
+
+fluid.init = function(functions)
+    base_functions = functions
+end
+
+fluid.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, is_label)
+    -- locals
+    local gui_translations = player_data.translations.gui
+
+    -- build string
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- fuel value
+    local fuel_value_str = ""
+    if obj_data.fuel_value then
+        fuel_value_str = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.fuel_value)
+        .." "
+        ..base_functions.fixed_format(obj_data.fuel_value, 3, "2")
+        .."J"
+        )
+    end
+    -- interaction help
+    local interaction_help_str = ""
+    if not is_label then
+        interaction_help_str = "\n"..gui_translations.click_to_view
+        if obj_data.temperature_data then
+        interaction_help_str = interaction_help_str.."\n"..gui_translations.shift_click_to_view_base_fluid
+        end
+    end
+
+    return base_str..fuel_value_str..interaction_help_str
+end
+
+return fluid

--- a/src/scripts/tooltip-formatters/item.lua
+++ b/src/scripts/tooltip-formatters/item.lua
@@ -1,0 +1,53 @@
+local item = {}
+
+local base_functions
+
+item.init = function(functions)
+    base_functions = functions
+end
+
+item.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, is_label)
+    -- locals
+    local gui_translations = player_data.translations.gui
+
+    -- object properties
+    local stack_size = obj_data.stack_size
+
+    -- build string
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- stack size
+    local stack_size_str = ""
+    if stack_size then
+      stack_size_str = "\n"..base_functions.build_rich_text("font", "default-semibold", gui_translations.stack_size).." "..stack_size
+    end
+    -- fuel category
+    local fuel_category_str = ""
+    if obj_data.fuel_category then
+      fuel_category_str = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.fuel_category)
+        .." "
+        ..obj_data.fuel_category
+      )
+    end
+    -- fuel value
+    local fuel_value_str = ""
+    if obj_data.fuel_value then
+      fuel_value_str = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.fuel_value)
+        .." "
+        ..base_functions.fixed_format(obj_data.fuel_value, 3, "2")
+        .."J"
+      )
+    end
+    -- interaction help
+    local interaction_help_str = ""
+    if not is_label then
+      interaction_help_str = "\n"..gui_translations.click_to_view
+    end
+
+    return base_str..stack_size_str..fuel_category_str..fuel_value_str..interaction_help_str
+  end
+
+return item

--- a/src/scripts/tooltip-formatters/lab.lua
+++ b/src/scripts/tooltip-formatters/lab.lua
@@ -1,0 +1,24 @@
+local lab = {}
+
+local math = require("__flib__.math")
+
+local base_functions
+
+lab.init = function(functions)
+    base_functions = functions
+end
+
+lab.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, _)
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- researching speed
+    local researching_speed_str = (
+      "\n"
+      ..base_functions.build_rich_text("font", "default-semibold", player_data.translations.gui.researching_speed)
+      .." "
+      ..math.round_to(obj_data.researching_speed, 2)
+    )
+
+    return base_str..researching_speed_str
+end
+
+return lab

--- a/src/scripts/tooltip-formatters/offshore-pump.lua
+++ b/src/scripts/tooltip-formatters/offshore-pump.lua
@@ -1,0 +1,29 @@
+local offshore_pump = {}
+
+local math = require("__flib__.math")
+
+local base_functions
+
+offshore_pump.init = function(functions)
+    base_functions = functions
+end
+
+offshore_pump.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, _)
+    -- locals
+    local gui_translations = player_data.translations.gui
+
+    -- build string
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- pumping speed
+    local pumping_speed_str = (
+      "\n"
+      ..base_functions.build_rich_text("font", "default-semibold", gui_translations.pumping_speed)
+      .." "
+      ..math.round_to(obj_data.pumping_speed * 60, 0)
+      ..gui_translations.per_second
+    )
+
+    return base_str..pumping_speed_str
+end
+
+return offshore_pump

--- a/src/scripts/tooltip-formatters/recipe.lua
+++ b/src/scripts/tooltip-formatters/recipe.lua
@@ -1,0 +1,78 @@
+local recipe = {}
+
+local math = require("__flib__.math")
+
+local base_functions
+
+recipe.init = function(functions)
+    base_functions = functions
+end
+
+local ingredients_products_keys = {ingredients = true, products = true}
+
+recipe.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, is_label)
+    -- locals
+    local recipe_book = global.recipe_book
+    local gui_translations = player_data.translations.gui
+    local player_settings = player_data.settings
+
+    -- build string
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    -- crafting_category
+    local category_str = (
+      "\n"
+      ..base_functions.build_rich_text("font", "default-semibold", gui_translations.category)
+      .." "
+      ..obj_data.category
+    )
+    -- crafting time, ingredients and products
+    local ip_str_arr = {}
+    if player_settings.show_detailed_recipe_tooltips and not is_label then
+      -- crafting time
+      ip_str_arr[1] = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.crafting_time)
+        .." "..math.round_to(obj_data.energy, 2)
+        .." "
+        ..gui_translations.seconds_standalone
+      )
+      -- ingredients and products
+      for material_type in pairs(ingredients_products_keys) do
+        local materials = obj_data[material_type]
+        local materials_len = #materials
+        if materials_len > 0 then
+          ip_str_arr[#ip_str_arr+1] = (
+            "\n"
+            ..base_functions.build_rich_text("font", "default-semibold", gui_translations[material_type.."_tooltip"])
+          )
+          for i = 1, #materials do
+            local material = materials[i]
+            local material_data = recipe_book[material.class][material.name]
+            if material_data then
+              local data = base_functions.formatter(
+                material_data,
+                player_data,
+                {amount_string = material.amount_string, always_show = true}
+              )
+              local label = data.caption
+              if data.is_researched then
+                ip_str_arr[#ip_str_arr+1] = "\n  "..label
+              else
+                ip_str_arr[#ip_str_arr+1] = "\n  "..base_functions.build_rich_text("color", "unresearched", label)
+              end
+            end
+          end
+        end
+      end
+    end
+    local ip_str = base_functions.concat(ip_str_arr)
+    -- interaction help
+    local interaction_help_str = ""
+    if not is_label then
+      interaction_help_str = "\n"..gui_translations.click_to_view
+    end
+
+    return base_str..category_str..ip_str..interaction_help_str
+end
+
+return recipe

--- a/src/scripts/tooltip-formatters/resource.lua
+++ b/src/scripts/tooltip-formatters/resource.lua
@@ -1,0 +1,39 @@
+local resource = {}
+
+local base_functions
+
+resource.init = function(functions)
+    base_functions = functions
+end
+
+resource.tooltip_formatter = function(obj_data, player_data, is_hidden, is_researched, _)
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    local required_fluid_str = ""
+    local interaction_help_str = ""
+    local required_fluid = obj_data.required_fluid
+    if required_fluid then
+      local fluid_data = global.recipe_book.fluid[required_fluid.name]
+      if fluid_data then
+        local data = base_functions.formatter(fluid_data, player_data, {amount_string = required_fluid.amount_string})
+        local label = data.caption
+        -- remove glyph from caption, since it's implied
+        if player_data.settings.show_glyphs then
+          label = string.gsub(label, "^.-nt%]  ", "")
+        end
+        if not data.is_researched then
+          label = base_functions.build_rich_text("color", "unresearched", label)
+        end
+        required_fluid_str = (
+          "\n"
+          ..base_functions.build_rich_text("font", "default-semibold", player_data.translations.gui.required_fluid)
+          .."  "
+          ..label
+        )
+        interaction_help_str = "\n"..player_data.translations.gui.click_to_view_required_fluid
+      end
+    end
+    return base_str..required_fluid_str..interaction_help_str
+  end
+
+
+return resource

--- a/src/scripts/tooltip-formatters/technology.lua
+++ b/src/scripts/tooltip-formatters/technology.lua
@@ -1,0 +1,73 @@
+local technology = {}
+
+local base_functions
+
+technology.init = function(functions)
+    base_functions = functions
+end
+
+technology.tooltip_formatter = function( obj_data, player_data, is_hidden, is_researched, is_label)
+    local base_str = base_functions.get_base_tooltip(obj_data, player_data, is_hidden, is_researched)
+    local gui_translations = player_data.translations.gui
+    local player_settings = player_data.settings
+    local recipe_book = global.recipe_book
+
+    -- units count, ingredients
+    local tech_str_arr = {}
+    if player_settings.show_detailed_recipe_tooltips and not is_label then
+      -- units count
+      local unit_count = obj_data.research_unit_count or game.evaluate_expression(
+        obj_data.research_unit_count_formula,
+        {L = obj_data.min_level, l = obj_data.min_level}
+      )
+
+      tech_str_arr[1] = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.research_units_tooltip)
+        .." "..unit_count
+      )
+      tech_str_arr[#tech_str_arr+1] = (
+        "\n"
+        ..base_functions.build_rich_text("font", "default-semibold", gui_translations.research_ingredients_per_unit_tooltip)
+      )
+
+      -- time ingredient
+      if obj_data.research_unit_energy then
+        local time_item_prefix = player_data.settings.show_glyphs and "[font=RecipeBook]Z[/font]   " or ""
+        tech_str_arr[#tech_str_arr+1] = "\n  ".. time_item_prefix.."[img=quantity-time]   "
+        ..obj_data.research_unit_energy.." "..gui_translations.seconds_standalone
+                  
+      end
+      -- ingredients
+      local ingredients = obj_data.research_ingredients_per_unit
+      for i = 1, #ingredients do
+        local ingredient = ingredients[i]
+        local ingredient_data = recipe_book[ingredient.class][ingredient.name]
+        if ingredient_data then
+          local data = base_functions.formatter(
+            ingredient_data,
+            player_data,
+            {amount_string = ingredient.amount_string, always_show = true}
+          )
+          local label = data.caption
+          if data.is_researched then
+            tech_str_arr[#tech_str_arr+1] = "\n  "..label
+          else
+            tech_str_arr[#tech_str_arr+1] = "\n  "..base_functions.build_rich_text("color", "unresearched", label)
+          end
+        end
+      end
+    end
+
+    local tech_str = base_functions.concat(tech_str_arr)
+    -- interaction help
+    local interaction_help_str = ""
+    if not is_label then
+      interaction_help_str = "\n"..gui_translations.click_to_view
+      interaction_help_str = interaction_help_str.."\n"..player_data.translations.gui.shift_click_to_view_technology
+    end
+
+    return base_str..tech_str..interaction_help_str
+end
+
+return technology


### PR DESCRIPTION
Work in progress on Technolgy page - part II not mentioned to finish te PR

- extended tooltip for technolgy, not sure if put there also unlocked recipes, now only units count and ingredients
- added two lists to technology page for unlocked items and unlocked fluids
- [Experimental] added list with technology bonuses, like braking force, ammo damage, since the bonuses are not prototype based, it is not simple to get needed info to display correct all possible bonuses from base game, not mentioning possible new bonuses from mods like QoL research (I included it to PR just to show you if you are interested in it, but as i see it now, it would cost too much work with quite small benefit to the mod, and it should be removed)