### PR TITLE
Fix invalid prototypes

### DIFF
--- a/src/scripts/processors/item.lua
+++ b/src/scripts/processors/item.lua
@@ -12,6 +12,10 @@ function item_proc.build(recipe_book, dictionaries, metadata)
   local rocket_launch_payloads = {}
 
   for name, prototype in pairs(global.prototypes.item) do
+    if not prototype.valid then
+      goto prototype_built
+    end
+
     -- Group
     local group = prototype.group
     local group_data = recipe_book.group[group.name]
@@ -135,6 +139,8 @@ function item_proc.build(recipe_book, dictionaries, metadata)
     }
     dictionaries.item:add(name, prototype.localised_name)
     dictionaries.item_description:add(name, prototype.localised_description)
+
+    ::prototype_built::
   end
 
   -- Add rocket launch payloads to their material tables

--- a/src/scripts/processors/recipe.lua
+++ b/src/scripts/processors/recipe.lua
@@ -8,6 +8,10 @@ local fluid_proc = require("scripts.processors.fluid")
 
 return function(recipe_book, dictionaries, metadata)
   for name, prototype in pairs(global.prototypes.recipe) do
+    if not prototype.valid then
+      goto prototype_built
+    end
+
     local category = prototype.category
     local group = prototype.group
 
@@ -115,5 +119,7 @@ return function(recipe_book, dictionaries, metadata)
     recipe_book.recipe[name] = data
     dictionaries.recipe:add(name, prototype.localised_name)
     dictionaries.recipe_description:add(name, prototype.localised_description)
+
+    ::prototype_built::
   end
 end


### PR DESCRIPTION
Thanks for the awesome mod!

I recently encountered these errors while loading my save file:

<img src="https://user-images.githubusercontent.com/15987992/136332667-a5e4c53e-f371-4785-94d4-ad77e9297996.png" height="300" /> <img src="https://user-images.githubusercontent.com/15987992/136332753-a3168ac1-72ac-4b75-8832-c439076c764c.png" height="300" />

From the [official API](https://lua-api.factorio.com/latest/Common.html#Common.valid):

> Is this object valid? This Lua object holds a reference to an object within the game engine. It is possible that the game-engine object is removed whilst a mod still holds the corresponding Lua object. If that happens, the object becomes invalid, i.e. this attribute will be false. Mods are advised to check for object validity if any change to the game state might have occurred between the creation of the Lua object and its access.

This PR adds the validity checks in two places they were missing. I tested it by modifying my local copy of the mod and reloading. Errors are gone. In any case, ignoring an invalid entity is significantly better than crashing during load.

